### PR TITLE
Point links to GitHub Pages site

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > This theme is designed by Xiaoying Riley at [3rd Wave Media](http://themes.3rdwavemedia.com/).
 > Visit [her website](http://themes.3rdwavemedia.com/) for more themes.
 
-I have made this into a Jekyll Theme. Checkout the live demo [here](https://online-cv.webjeda.com).
+I have made this into a Jekyll Theme. Checkout the live demo [here](https://josemodi97.github.io/online-cv).
 
 <table>
   <tr>
@@ -15,10 +15,10 @@ I have made this into a Jekyll Theme. Checkout the live demo [here](https://onli
   </tr>
   <tr>
     <td>
-        <img src="https://online-cv.webjeda.com/assets/images/desktop.png?raw=true" width="600"/>
+        <img src="https://josemodi97.github.io/online-cv/assets/images/desktop.png?raw=true" width="600"/>
     </td>
     <td>
-        <img src="https://online-cv.webjeda.com/assets/images/mobile.png?raw=true" width="250"/>
+        <img src="https://josemodi97.github.io/online-cv/assets/images/mobile.png?raw=true" width="250"/>
     </td>
   </tr>
 </table>
@@ -27,8 +27,8 @@ I have made this into a Jekyll Theme. Checkout the live demo [here](https://onli
 
 * [Fork](https://github.com/sharu725/online-cv/fork) the repository;
 * Go to settings and set master branch as Github Pages source;
-* Your new site should be ready at `https://<username>.github.io/online-cv/`;
-* Printable version of the site can be found at `https://<username>.github.io/online-cv/print`. Use a third party link https://pdflayer.com/, https://www.web2pdfconvert.com/ etc to get the printable PDF.
+* Your new site should be ready at `https://josemodi97.github.io/online-cv/`;
+* Printable version of the site can be found at `https://josemodi97.github.io/online-cv/print`. Use a third party link https://pdflayer.com/, https://www.web2pdfconvert.com/ etc to get the printable PDF.
 
 Change all the details from one place: `_data/data.yml`.
 
@@ -70,11 +70,11 @@ There are 6 color schemes available:
 
 | Blue | Turquoise | Green |
 |---------|---------|---------|
-| <img src="https://online-cv.webjeda.com/assets/images/blue.jpg" width="300"/> | <img src="https://online-cv.webjeda.com/assets/images/turquoise.jpg" width="300"/> | <img src="https://online-cv.webjeda.com/assets/images/green.jpg" width="300"/> |
+| <img src="https://josemodi97.github.io/online-cv/assets/images/blue.jpg" width="300"/> | <img src="https://josemodi97.github.io/online-cv/assets/images/turquoise.jpg" width="300"/> | <img src="https://josemodi97.github.io/online-cv/assets/images/green.jpg" width="300"/> |
 
 | Berry | Orange | Ceramic |
 |---------|---------|---------|
-| <img src="https://online-cv.webjeda.com/assets/images/berry.jpg" width="300"/> | <img src="https://online-cv.webjeda.com/assets/images/orange.jpg" width="300"/> | <img src="https://online-cv.webjeda.com/assets/images/ceramic.jpg" width="300"/> |
+| <img src="https://josemodi97.github.io/online-cv/assets/images/berry.jpg" width="300"/> | <img src="https://josemodi97.github.io/online-cv/assets/images/orange.jpg" width="300"/> | <img src="https://josemodi97.github.io/online-cv/assets/images/ceramic.jpg" width="300"/> |
 
 ## Credits
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 
 # Site Settings
 title: My Resume
-url: 'http://webjeda.com'
+url: 'https://josemodi97.github.io'
 
 #change it according to your repository name
 # disabling since we are using a custom domain

--- a/_data/data.yml
+++ b/_data/data.yml
@@ -8,7 +8,7 @@ sidebar:
   email: odhisjoseph85@gmail.com
   phone: "+254799213371"
   timezone: Africa/Nairobi
-  website: josemodi97.github.io/about/
+  website: josemodi97.github.io/online-cv/
   github: josemodi97
   languages:
     title: Languages


### PR DESCRIPTION
## Summary
- update README links to use josemodi97.github.io
- configure Jekyll site URL
- set website contact link to GitHub Pages address

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_684ef3c254bc8329b742a7e265c27b1f