### PR TITLE
Cleanup README and contact link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,24 @@
-<a href="https://jekyll-themes.com">
-<img src="https://img.shields.io/badge/featured%20on-JT-red.svg" height="20" alt="Jekyll Themes Shield" >
-</a>
+# Joseph Modi Odhiambo - Online CV
 
-# Orbit
-> This theme is designed by Xiaoying Riley at [3rd Wave Media](http://themes.3rdwavemedia.com/).
-> Visit [her website](http://themes.3rdwavemedia.com/) for more themes.
+This repository contains the source code for my online resume hosted at [https://josemodi97.github.io/online-cv](https://josemodi97.github.io/online-cv).
 
-I have made this into a Jekyll Theme. Checkout the live demo [here](https://online-cv.webjeda.com).
+## Running Locally
 
-<table>
-  <tr>
-    <th>Desktop</th>
-    <th>Mobile</th>
-  </tr>
-  <tr>
-    <td>
-        <img src="https://online-cv.webjeda.com/assets/images/desktop.png?raw=true" width="600"/>
-    </td>
-    <td>
-        <img src="https://online-cv.webjeda.com/assets/images/mobile.png?raw=true" width="250"/>
-    </td>
-  </tr>
-</table>
-
-## Installation
-
-* [Fork](https://github.com/sharu725/online-cv/fork) the repository;
-* Go to settings and set master branch as Github Pages source;
-* Your new site should be ready at `https://<username>.github.io/online-cv/`;
-* Printable version of the site can be found at `https://<username>.github.io/online-cv/print`. Use a third party link https://pdflayer.com/, https://www.web2pdfconvert.com/ etc to get the printable PDF.
-
-Change all the details from one place: `_data/data.yml`.
-
-### To preview/edit locally with docker
+Start a local server with Docker:
 
 ```sh
 docker-compose up
 ```
 
-*docker-compose.yml* file is used to create a container that is reachable under <http://localhost:4000>.
-Changes *_data/data.yml* will be visible after a while.
+The site will be available at <http://localhost:4000>.
 
-### Local machine
-
-* Get the repo into your machine 
-
-```bash
-git clone https://github.com/sharu725/online-cv.git
-```
-
-* Install required ruby gems
+Alternatively, with Ruby installed:
 
 ```bash
 bundle install
-```
-
-* Serve the site locally
-
-```bash
 bundle exec jekyll serve
 ```
 
-* Navigate to `http://localhost:4000`
+## License
 
-
-## Skins
-
-There are 6 color schemes available:
-
-| Blue | Turquoise | Green |
-|---------|---------|---------|
-| <img src="https://online-cv.webjeda.com/assets/images/blue.jpg" width="300"/> | <img src="https://online-cv.webjeda.com/assets/images/turquoise.jpg" width="300"/> | <img src="https://online-cv.webjeda.com/assets/images/green.jpg" width="300"/> |
-
-| Berry | Orange | Ceramic |
-|---------|---------|---------|
-| <img src="https://online-cv.webjeda.com/assets/images/berry.jpg" width="300"/> | <img src="https://online-cv.webjeda.com/assets/images/orange.jpg" width="300"/> | <img src="https://online-cv.webjeda.com/assets/images/ceramic.jpg" width="300"/> |
-
-## Credits
-
-Thanks to [Nelson Estevão](https://github.com/nelsonmestevao) for all the [contributions](https://github.com/sharu725/online-cv/commits?author=nelsonmestevao).
-
-Thanks to [t-h-e(sfrost)](https://github.com/t-h-e) for all the [contributions](https://github.com/sharu725/online-cv/commits?author=t-h-e).
-
-Check out for more themes: [**Jekyll Themes**](http://jekyll-themes.com).
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=sharu725/online-cv&type=Date)](https://star-history.com/#sharu725/online-cv&Date)
-
+The layout is based on the [Orbit](http://themes.3rdwavemedia.com/) theme by 3rd Wave Media.

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 
 # Site Settings
 title: My Resume
-url: 'http://webjeda.com'
+url: 'https://josemodi97.github.io'
 
 #change it according to your repository name
 # disabling since we are using a custom domain

--- a/_data/data.yml
+++ b/_data/data.yml
@@ -8,7 +8,7 @@ sidebar:
   email: odhisjoseph85@gmail.com
   phone: "+254799213371"
   timezone: Africa/Nairobi
-  website: josemodi97.github.io/about/
+  website: https://josemodi97.github.io/online-cv/
   github: josemodi97
   languages:
     title: Languages


### PR DESCRIPTION
## Summary
- remove theme marketing and extra sections from README
- keep simple instructions for viewing CV
- update personal website URL in data file

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_684ef3c254bc8329b742a7e265c27b1f